### PR TITLE
Add a test for the bug of forward-mode for cluster-replication

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,7 +15,155 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1634851050,
+        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flare": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "flare-tests": "flare-tests",
+        "flare-tools": "flare-tools",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1646028281,
+        "narHash": "sha256-QuxcHyD3x+pSXnsGQiuzsr83q/9FRvsRY7c2Jk+2hAw=",
+        "owner": "gree",
+        "repo": "flare",
+        "rev": "9b1e2a9a987113f1c0c7873fe591fbe7b673f7e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gree",
+        "repo": "flare",
+        "type": "github"
+      }
+    },
+    "flare-tests": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1635299804,
+        "narHash": "sha256-0giWBWqmtu51Oqg36OeqpuXCmaJC8VeGtTXtD0/YdwE=",
+        "owner": "gree",
+        "repo": "flare-tests",
+        "rev": "2c0df517b486ddc4f19ee07f69711e564ae490f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gree",
+        "repo": "flare-tests",
+        "type": "github"
+      }
+    },
+    "flare-tools": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1645783248,
+        "narHash": "sha256-PXvAsTxffTiO79vri1YKMplvHJRFaCv25PF74iYcv08=",
+        "owner": "gree",
+        "repo": "flare-tools",
+        "rev": "2c030d70dbbf239b2cca1948411c8e6df278b8e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gree",
+        "repo": "flare-tools",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1635261841,
+        "narHash": "sha256-TsPBFEIarRkpDoqIX0cqi4PxYq2w1oVygElpPokIDaU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2558d8e64f3816ec4291555fc8dc2212bd21f0a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1645623357,
+        "narHash": "sha256-vAaI91QFn/kY/uMiebW+kG2mPmxirMSJWYtkqkBKdDc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9222ae36b208d1c6b55d88e10aa68f969b5b5244",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1635261841,
+        "narHash": "sha256-TsPBFEIarRkpDoqIX0cqi4PxYq2w1oVygElpPokIDaU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2558d8e64f3816ec4291555fc8dc2212bd21f0a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1635261841,
         "narHash": "sha256-TsPBFEIarRkpDoqIX0cqi4PxYq2w1oVygElpPokIDaU=",
@@ -33,7 +181,8 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flare": "flare",
+        "nixpkgs": "nixpkgs_4"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -8,50 +8,72 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
+    flare.url = "github:gree/flare";
   };
 
   outputs = { self
             , nixpkgs
             , flake-utils
+            , flare
             , ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = import nixpkgs {inherit system;
                                  config.allowBroken = true;
                                 };
-          test-sandbox = pkgs.haskell.lib.dontCheck
-            (pkgs.haskellPackages.callHackageDirect {
-              pkg = "test-sandbox";
-              ver = "0.1.9";
-              sha256 = "14vsv7crx3h0nwqy1f99q47riv70jal9izvshha7v1z15hkslmdz";
-            } {});
-          test-sandbox-hunit =  pkgs.haskell.lib.dontCheck
-            (pkgs.haskellPackages.callHackageDirect {
-              pkg = "test-sandbox-hunit";
-              ver = "0.1.3";
-              sha256 = "1sh12xh604ik8dxgi1h0ml5hjpks1dwa1k73k98c78p2hzl2g30h";
-            } {inherit test-sandbox;});
-          test-framework-sandbox = pkgs.haskell.lib.dontCheck
-            (pkgs.haskellPackages.callHackage
-              "test-framework-sandbox"
-              "0.1.1"
-              {inherit test-sandbox;});
-          test-sandbox-quickcheck = pkgs.haskell.lib.dontCheck
-            (pkgs.haskellPackages.callHackage
-              "test-sandbox-quickcheck"
-              "0.1.0"
-              {inherit test-sandbox;});
-          flare-tests = with pkgs.haskell.lib;  pkgs.haskellPackages.callCabal2nix "flare-tests" ./. 
-            {
-            inherit test-sandbox;
-            inherit test-framework-sandbox;
-            inherit test-sandbox-hunit;
-            inherit test-sandbox-quickcheck;
+          compiler = "ghc8107";
+          haskellPackages = pkgs.haskell.packages.${compiler}.override {
+            overrides = hpNew: hpOld: rec {
+              test-sandbox = pkgs.haskell.lib.dontCheck
+                (pkgs.haskellPackages.callHackageDirect {
+                  pkg = "test-sandbox";
+                  ver = "0.1.9";
+                  sha256 = "14vsv7crx3h0nwqy1f99q47riv70jal9izvshha7v1z15hkslmdz";
+                } {});
+              test-sandbox-hunit =  pkgs.haskell.lib.dontCheck
+                (pkgs.haskellPackages.callHackageDirect {
+                  pkg = "test-sandbox-hunit";
+                  ver = "0.1.3";
+                  sha256 = "1sh12xh604ik8dxgi1h0ml5hjpks1dwa1k73k98c78p2hzl2g30h";
+                } {inherit test-sandbox;});
+              test-framework-sandbox = pkgs.haskell.lib.dontCheck
+                (pkgs.haskellPackages.callHackage
+                  "test-framework-sandbox"
+                  "0.1.1"
+                  {inherit test-sandbox;});
+              test-sandbox-quickcheck = pkgs.haskell.lib.dontCheck
+                (pkgs.haskellPackages.callHackage
+                  "test-sandbox-quickcheck"
+                  "0.1.0"
+                  {inherit test-sandbox;});
+              flare-tests = with pkgs.haskell.lib;  pkgs.haskellPackages.callCabal2nix "flare-tests" ./. 
+                {
+                  inherit test-sandbox;
+                  inherit test-framework-sandbox;
+                  inherit test-sandbox-hunit;
+                  inherit test-sandbox-quickcheck;
+                };
+            };
           };
       in {
         # Exported packages.
-        defaultPackage = flare-tests;
+        defaultPackage = haskellPackages.flare-tests;
         packages = {
-          inherit flare-tests;
+          flare-tests = haskellPackages.flare-tests;
+        };
+        devShell = haskellPackages.shellFor {
+          packages = p: [
+            p.flare-tests
+          ];
+          # for running doctests locally
+          nativeBuildInputs = [
+            pkgs.haskellPackages.doctest
+            pkgs.haskellPackages.cabal-install
+            flare.packages.${system}.flare
+          ];
+
+          # set environment variable, so the development version of
+          # distribution-nixpkgs finds derivation-attr-paths.nix
+          distribution_nixpkgs_datadir = toString ./distribution-nixpkgs;
         };
       }
     );

--- a/src/ClusterReplicationTests.hs
+++ b/src/ClusterReplicationTests.hs
@@ -1,0 +1,116 @@
+-- author: Benjamin Surma <benjamin.surma@gree.net>
+
+module ClusterReplicationTests (clusterReplicationTests) where
+
+import Test.Framework
+import Test.Framework.Providers.Sandbox (sandboxTests, sandboxTest, sandboxTestGroup, yieldProgress)
+import Test.Sandbox
+
+import GHC.Conc
+import System.FilePath
+import System.Directory
+import Control.Monad (void)
+
+import Main.Internals (assertSendTo, getFlareRoot)
+
+registerNode :: String -> String -> String -> Sandbox ()
+registerNode indexName daemonName dir = do
+  liftIO $ createDirectory (dir ++ "/" ++ daemonName)
+  bin <- getVariable "flared_bin" "flared"
+  flareiPort <- getPort indexName
+  port <- getPort daemonName
+  void $ register daemonName bin [ "--data-dir", (dir ++ "/" ++ daemonName)
+                                 , "--index-server-name", "localhost"
+                                 , "--index-server-port", show flareiPort
+                                 , "--replication-type", "sync"
+                                 , "--server-name", "localhost"
+                                 , "--server-port", show port
+                                 ] def { psWait = Nothing }
+
+registerReplicaNode :: String -> String -> String -> String -> String -> Sandbox ()
+registerReplicaNode indexName daemonName dir backwardServerName replicationMode = do
+  liftIO $ createDirectory (dir ++ "/" ++ daemonName)
+  bin <- getVariable "flared_bin" "flared"
+  flareiPort <- getPort indexName
+  port <- getPort daemonName
+  backwardPort <- getPort backwardServerName
+  void $ register daemonName bin [ "--data-dir", (dir ++ "/" ++ daemonName)
+                                 , "--index-server-name", "localhost"
+                                 , "--index-server-port", show flareiPort
+                                 , "--replication-type", "sync"
+                                 , "--server-name", "localhost"
+                                 , "--server-port", show port
+                                 , "--cluster-replication", "true"
+                                 , "--cluster-replication-server-name", "localhost"
+                                 , "--cluster-replication-server-port", show backwardPort
+                                 , "--cluster-replication-concurrency", "2"
+                                 , "--cluster-replication-mode", replicationMode
+                                 ] def { psWait = Nothing }
+
+
+
+registerIndex :: String -> String -> Sandbox ()
+registerIndex indexName dir = do
+  liftIO $ createDirectory (dir ++ "/" ++ indexName)
+  bin <- getVariable "flarei_bin" "flarei"
+  flareiPort <- getPort indexName
+  void $ register indexName bin [ "--data-dir", dir ++ "/" ++ indexName
+                                , "--server-name", "localhost"
+                                , "--server-port", show flareiPort
+                                , "--monitor-interval", "1"
+                                , "--monitor-threshold", "2"
+                                ] def
+
+
+setupWithPath :: Maybe FilePath -> Sandbox ()
+setupWithPath binDir = do
+  -- Register index server
+  rootDir <- liftIO getFlareRoot
+  let flareiBin = case (binDir, rootDir) of
+                    (Just v, _) -> v </> "flarei"
+                    (_, Just v) -> v </> "src" </> "flarei" </> "flarei"
+                    (_, Nothing) -> "/usr" </> "local" </> "bin" </> "flarei"
+      flaredBin = case (binDir, rootDir) of
+                    (Just v, _) -> v </> "flared"
+                    (_, Just v) -> v </> "src" </> "flared" </> "flared"
+                    (_, Nothing) -> "/usr" </> "local" </> "bin" </> "flared"
+  setVariable "flarei_bin" flareiBin
+  setVariable "flared_bin" flaredBin
+
+  dataDir <- getDataDir
+  registerIndex "backward-flarei" dataDir
+  registerNode "backward-flarei" "backward-master-0" dataDir
+  registerIndex "forward-flarei" dataDir
+  registerReplicaNode "forward-flarei" "forward-master-0" dataDir "backward-master-0" "forward"
+  startAll
+  liftIO $ threadDelay 1000000
+  setupFlareDaemon "backward-flarei" "backward-master-0"
+  setupFlareDaemon "forward-flarei" "forward-master-0"
+  liftIO $ threadDelay 1000000
+
+setupFlareDaemon :: String -> String -> Sandbox ()
+setupFlareDaemon indexName nodeName = do
+  yieldProgress $ "Setting up " ++ indexName
+  port <- getPort nodeName
+  void $ assertSendTo indexName ("node role " ++ "localhost " ++ show port ++ " master 1 0\r\n") "OK\r\n"
+
+clusterReplicationTests :: Maybe FilePath -> Test
+clusterReplicationTests binDir = sandboxTests "cluster-replication" [
+    sandboxTest "flared setup" $ setupWithPath binDir
+  , sandboxTest "1. forward bug" forwardTest
+  ]
+
+forwardTest :: Sandbox ()
+forwardTest = do
+  let forward = "forward-master-0"
+      backward  = "backward-master-0"
+  assertSendTo backward "set 1::key 0 0 5\r\nvalue\r\n" "STORED\r\n"
+  assertSendTo forward "gets 1::key\r\n" "VALUE 1::key 0 5 1\r\nvalue\r\nEND\r\n"
+  assertSendTo backward "gets 1::key\r\n" "VALUE 1::key 0 5 1\r\nvalue\r\nEND\r\n"
+  assertSendTo forward "cas 1::key 0 0 5 1\r\nValue\r\n" "STORED\r\n"
+  assertSendTo forward "gets 1::key\r\n" "VALUE 1::key 0 5 2\r\nValue\r\nEND\r\n"
+  assertSendTo backward "gets 1::key\r\n" "VALUE 1::key 0 5 2\r\nValue\r\nEND\r\n"
+  assertSendTo forward "delete 1::key\r\n" "DELETED\r\n"
+  assertSendTo forward "gets 1::key\r\n" "END\r\n"
+  assertSendTo backward "gets 1::key\r\n" "END\r\n"
+  liftIO $ threadDelay 3000000 -- wait 3.

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -6,6 +6,7 @@ import FailoverTests (failoverTests)
 import ProtocolTests (protocolTests)
 import Properties (properties)
 import ReplicationTests (replicationTests)
+import ClusterReplicationTests (clusterReplicationTests)
 import Options
 
 import System.Console.CmdArgs
@@ -16,6 +17,7 @@ main = do
   options <- cmdArgs defaultOptions
   let binDir = flare_bin_dir options
   defaultMainWithArgs [ (failoverTests binDir)
-                        , (protocolTests binDir)
-                        , (properties binDir)
-                        , (replicationTests binDir) ] []
+                      , (protocolTests binDir)
+                      , (properties binDir)
+                      , (replicationTests binDir)
+                      , (clusterReplicationTests binDir) ] []


### PR DESCRIPTION
https://github.com/gree/flare/pull/132 のバグをテストするパターンです。

下記のようにflareのmasterブランチ(9b1e2a9a987113f1c0c7873fe591fbe7b673f7e8)では失敗します。

```
[dev-flare-tests:~/git/flare-tests]$ cabal run
Up to date
[cluster-replication]
  [flared setup]
##------------------------------------------------------------------------------
 ## cluster-replication system test environment                               --
## ##---------------------------------------------------------------------------
-- Data directory: /tmp/nix-shell.JmG3q1/cluster-replication_-afd14269a42bb436
-- Allocated ports: ("backward-flarei",18169) ("backward-master-0",24022) ("forward-flarei",23352) ("forward-master-0",32321)
-- Configuration files:
-- Registered processes: backward-flarei backward-master-0 forward-flarei forward-master-0
--------------------------------------------------------------------------------

Starting all sandbox processes...
Done.
Setting up backward-flarei / Setting up forward-flarei [OK]
  [1. forward bug]  [Fail] cas 1::key 0 0 5 1
Value

expected: "STORED\r\n"
 but got: "NOT_FOUND\r\n"
Stopping all sandbox processes... Stopping process forward-master-0(Just 279940)...
sending sigterm : forward-master-0
Done.
Stopping process forward-flarei(Just 279930)...
sending sigterm : forward-flarei
Done.
Stopping process backward-master-0(Just 279928)...
sending sigterm : backward-master-0
Done.
Stopping process backward-flarei(Just 279922)...
sending sigterm : backward-flarei
Done.
Done.
cluster-replication:
  cluster-replication:
    flared setup: [OK]
    1. forward bug: [Failed]
Failure: cas 1::key 0 0 5 1
Value

expected: "STORED\r\n"
 but got: "NOT_FOUND\r\n"

         Sandbox tests  Total
 Passed  1              1
 Failed  1              1
 Total   2              2

```